### PR TITLE
MAINT: Add parasail headers to Python wheel.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ parasail.egg-info/
 *.dll
 parasail-master*
 autotools/
+parasail/include/**

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ include parasail/bindings_v2.py
 exclude parasail/libparasail.so
 exclude parasail/libparasail.dylib
 exclude parasail/parasail.dll
+recursive-exclude parasail/include *.h
 include setup.cfg
 include setup.py
 include tests/test_basic.py

--- a/parasail/__init__.py
+++ b/parasail/__init__.py
@@ -23,6 +23,7 @@ if platform.system() == 'Darwin':
 elif platform.system() == 'Windows':
     _libname = "parasail.dll"
 _libpath = os.path.join(os.path.dirname(__file__), _libname)
+_includepath = os.path.join(os.path.dirname(__file__), "include")
 
 _verbose = os.environ.get("PARASAIL_VERBOSE", False)
 
@@ -92,3 +93,12 @@ if major == 1:
 else:
     from parasail.bindings_v2 import *
 
+def get_include():
+    """ Returns the path of the Parasail C library include files.
+    """
+    return _includepath
+
+def get_library():
+    """ Returns the path of the Parasail C library shared object file.
+    """
+    return _libpath


### PR DESCRIPTION
fixes #51 

This adds the header files from the C library to the Python wheel, so that external Python packages and libraries can link against Parasail (using e.g. Cython). On both Linux and Windows, the headers are copied over from the downloaded C library, so that they match the version of the shared object file that is bundled with the egg.

I've also added two convenience functions that allow users to get the locations of includes and libraries without having to dig inside the installed location:
```python
>>> import parasail
>>> parasail.get_include()
'/home/jvkersch/.edm/envs/parasail-clean/lib/python3.6/site-packages/parasail/include'
>>> parasail.get_library()
'/home/jvkersch/.edm/envs/parasail-clean/lib/python3.6/site-packages/parasail/libparasail.so'
```

I've verified that this works on Linux (by building the wheel and installing it in a new environment), and I'm reasonably confident that this works on Windows too, but I haven't tested on that platform.