### PR TITLE
Fix macos wheel generation in CI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,10 +16,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019]
+        os: [ubuntu-20.04, windows-2019, macos-11]
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install macos deps
+        if: startsWith(matrix.os, 'macos')
+        # automake is not included in the stock macos runner, which triggers `setup.py` to install all deps (not just
+        # the missing ones). However, the newly installed m4 binary fails on macos with a SIGABRT (though the original
+        # `brew` installed one does not) as documented in:
+        #     https://github.com/jeffdaily/parasail-python/issues/24.
+        run: brew install automake
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.9.0


### PR DESCRIPTION
macos wheels were removed before the 1.3 release because of failing builds as reported in https://github.com/jeffdaily/parasail-python/issues/65, which turns out to be caused by the same auto-installed m4 mac issues as documented in https://github.com/jeffdaily/parasail-python/issues/24 (SIGABRT). However, `setup.py` only installs m4 by hand because `automake` was missing, so this just installs automake first to bypass the `setup.py` installations.

[Here's a working build.](https://github.com/JacobHayes/parasail-python/runs/7992706096?check_suite_focus=true)

Closes #65.