### PR TITLE
arm64 linux builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,8 +34,8 @@ jobs:
         buildplat:
         - [ubuntu-latest, manylinux_x86_64, auto]
         - [ubuntu-latest, musllinux_i686, auto]
-        - [ubuntu-latest, manylinux_arm64, auto]
-        - [ubuntu-latest, musllinux_arm64, auto]
+        - [ubuntu-latest, manylinux_aarch64, auto]
+        - [ubuntu-latest, musllinux_aarch64, auto]
         - [windows-latest, win_amd64, auto]
         - [windows-latest, win32, auto]
         - [macos-latest, macosx_x86_64, x86_64]

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -34,8 +34,8 @@ jobs:
         buildplat:
         - [ubuntu-latest, manylinux_x86_64, auto]
         - [ubuntu-latest, musllinux_i686, auto]
-        - [ubuntu-latest, manylinux_x86_64, auto]
-        - [ubuntu-latest, musllinux_i686, auto]
+        - [ubuntu-latest, manylinux_arm64, auto]
+        - [ubuntu-latest, musllinux_arm64, auto]
         - [windows-latest, win_amd64, auto]
         - [windows-latest, win32, auto]
         - [macos-latest, macosx_x86_64, x86_64]


### PR DESCRIPTION
I'm assuming the list of build platforms is supposed to contain the arm targets rather than duplicate x86 ones?

I've come back to this because some of my own CI on ARM for other projects has started failing when its building parasail python module from source. Seems most sensible to fix the issue at source for everyone.